### PR TITLE
docs(readme): update source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ docker pull wealdtech/probed
 `probed` is a standard Go binary which can be installed with:
 
 ```sh
-go get github.com/wealdtech/probed
+go install github.com/wealdtech/probed@latest
 ```


### PR DESCRIPTION
using the command as supplied with the latest go:


```bash
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
```

Thank you